### PR TITLE
Add example with tracing as middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ defer span.Finish()
 docker run -d -p 9411:9411 openzipkin/zipkin
 go run examples/basic/main.go
 go run examples/httpServer/main.go
+go run examples/httpServer-middleware/main.go
 ```
 
 To watch traces you just have to hit http://localhost:9411/

--- a/examples/httpServer-middleware/main.go
+++ b/examples/httpServer-middleware/main.go
@@ -18,7 +18,7 @@ func main() {
 	tracing.SetGlobalTracer(appName, "http://localhost:9411/")
 	defer tracing.FlushCollector()
 
-	http.Handle("/", tracing.Middleware("hello-handler", hello))
+	http.Handle("/", tracing.HttpMiddleware("hello-handler", hello))
 	http.ListenAndServe(":8000", nil)
 }
 

--- a/examples/httpServer-middleware/main.go
+++ b/examples/httpServer-middleware/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ricardo-ch/go-tracing"
+	"github.com/ricardo-ch/go-tracing/examples/httpServer-middleware/middleware"
+)
+
+// this name is use to identify traces inside zipkin
+const (
+	appName = "my-http-server-middleware"
+)
+
+func main() {
+	tracing.SetGlobalTracer(appName, "http://localhost:9411/")
+	defer tracing.FlushCollector()
+
+	http.Handle("/", middleware.TracingMiddleware("hello-handler", hello))
+	http.ListenAndServe(":8000", nil)
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(1 * time.Second)
+	nestedFunc(r.Context())
+
+	io.WriteString(w, "Hello world!")
+}
+
+func nestedFunc(ctx context.Context) {
+	span, ctx := tracing.CreateSpan(ctx, "nestedFunc", nil)
+	defer span.Finish()
+
+	time.Sleep(1 * time.Second)
+}

--- a/examples/httpServer-middleware/main.go
+++ b/examples/httpServer-middleware/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ricardo-ch/go-tracing"
-	"github.com/ricardo-ch/go-tracing/examples/httpServer-middleware/middleware"
 )
 
 // this name is use to identify traces inside zipkin
@@ -19,7 +18,7 @@ func main() {
 	tracing.SetGlobalTracer(appName, "http://localhost:9411/")
 	defer tracing.FlushCollector()
 
-	http.Handle("/", middleware.TracingMiddleware("hello-handler", hello))
+	http.Handle("/", tracing.Middleware("hello-handler", hello))
 	http.ListenAndServe(":8000", nil)
 }
 

--- a/examples/httpServer-middleware/middleware/tracing.go
+++ b/examples/httpServer-middleware/middleware/tracing.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ricardo-ch/go-tracing"
+)
+
+// TracingMiddleware returns a Middleware that injects an OpenTracing Span found in
+// context into the HTTP Headers.
+func TracingMiddleware(operationName string, next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// set request parameters as tags
+		tags := make(map[string]interface{})
+		parameters := req.URL.Query()
+		for key, values := range parameters {
+			if len(values) == 1 {
+				tags[key] = values[0]
+			} else {
+				for i, value := range values {
+					tags[fmt.Sprintf("%s[%d]", key, i)] = value
+				}
+			}
+		}
+
+		span, ctx := tracing.CreateSpanFromClientContext(req, operationName, &tags)
+		defer span.Finish()
+
+		// update request context to include our new span
+		req = req.WithContext(ctx)
+
+		// next middleware or actual request handler
+		next(w, req)
+	})
+}

--- a/middleware.go
+++ b/middleware.go
@@ -1,18 +1,20 @@
-package middleware
+package tracing
 
 import (
 	"fmt"
 	"net/http"
-
-	"github.com/ricardo-ch/go-tracing"
 )
 
-// TracingMiddleware returns a Middleware that injects an OpenTracing Span found in
+// Middleware returns a Middleware that injects an OpenTracing Span found in
 // context into the HTTP Headers.
-func TracingMiddleware(operationName string, next http.HandlerFunc) http.Handler {
+func Middleware(operationName string, next http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// set request parameters as tags
 		tags := make(map[string]interface{})
+
+		// set whole URL as tag
+		tags["url"] = req.URL.String()
+
+		// set request parameters as tags
 		parameters := req.URL.Query()
 		for key, values := range parameters {
 			if len(values) == 1 {
@@ -24,7 +26,7 @@ func TracingMiddleware(operationName string, next http.HandlerFunc) http.Handler
 			}
 		}
 
-		span, ctx := tracing.CreateSpanFromClientContext(req, operationName, &tags)
+		span, ctx := CreateSpanFromClientContext(req, operationName, &tags)
 		defer span.Finish()
 
 		// update request context to include our new span

--- a/middleware.go
+++ b/middleware.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// Middleware returns a Middleware that injects an OpenTracing Span found in
+// HttpMiddleware returns a Middleware that injects an OpenTracing Span found in
 // context into the HTTP Headers.
-func Middleware(operationName string, next http.HandlerFunc) http.Handler {
+func HttpMiddleware(operationName string, next http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		tags := make(map[string]interface{})
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -15,7 +15,7 @@ import (
 func TestMiddleware(t *testing.T) {
 	assert := assert.New(t)
 
-	ts := httptest.NewServer(Middleware("test-get", getTestHandler))
+	ts := httptest.NewServer(HttpMiddleware("test-get", getTestHandler))
 	defer ts.Close()
 
 	var u bytes.Buffer

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,40 @@
+package tracing
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(Middleware("test-get", getTestHandler))
+	defer ts.Close()
+
+	var u bytes.Buffer
+	u.WriteString(string(ts.URL))
+
+	res, err := http.Get(u.String())
+	assert.NoError(err)
+	if res != nil {
+		defer res.Body.Close()
+	}
+
+	_, err = ioutil.ReadAll(res.Body)
+	assert.NoError(err)
+	assert.Equal(res.StatusCode, 200, "Span should be in the context")
+}
+
+func getTestHandler(rw http.ResponseWriter, req *http.Request) {
+	if span := opentracing.SpanFromContext(req.Context()); span != nil {
+		fmt.Fprint(rw, "span ok")
+	}
+	http.Error(rw, "SPAN_NOT_FOUND", 404)
+}


### PR DESCRIPTION
This example aims to demonstrate how to use the package in a middleware and set all query parameters in tags.