### PR TITLE
Replace middleware's signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker run -d -p 9411:9411 openzipkin/zipkin
 go run examples/basic/main.go
 go run examples/httpServer/main.go
 go run examples/httpServer-middleware/main.go
+go run examples/httpGoKit-middleware/main.go
 ```
 
 To watch traces you just have to hit http://localhost:9411/
@@ -37,4 +38,4 @@ To watch traces you just have to hit http://localhost:9411/
 go-tracing is licensed under the MIT license. (http://opensource.org/licenses/MIT)
 
 ## Contributing
-Pull requests are the way to help us here. We will be really gratefull.
+Pull requests are the way to help us here. We will be really grateful.

--- a/examples/httpGoKit-middleware/endpoint.go
+++ b/examples/httpGoKit-middleware/endpoint.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"context"
+	"github.com/go-kit/kit/endpoint"
+)
+
+func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(uppercaseRequest)
+		v, err := svc.Uppercase(ctx, req.S)
+		if err != nil {
+			return uppercaseResponse{v, err.Error()}, nil
+		}
+		return uppercaseResponse{v, ""}, nil
+	}
+}

--- a/examples/httpGoKit-middleware/main.go
+++ b/examples/httpGoKit-middleware/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/ricardo-ch/go-tracing"
+)
+
+// this name is use to identify traces inside zipkin
+const (
+	appName = "my-http-server-middleware"
+)
+
+func main() {
+	tracing.SetGlobalTracer(appName, "http://localhost:9411/")
+	defer tracing.FlushCollector()
+
+	svc := stringService{}
+	uppercaseHandler := httptransport.NewServer(
+		makeUppercaseEndpoint(svc),
+		decodeUppercaseRequest,
+		encodeResponse,
+	)
+
+	http.Handle("/uppercase", tracing.HTTPMiddleware("hello-handler", uppercaseHandler))
+	http.ListenAndServe(":8000", nil)
+}
+
+func uppercase(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(1 * time.Second)
+	nestedFunc(r.Context())
+
+	io.WriteString(w, "Hello world!")
+}
+
+func nestedFunc(ctx context.Context) {
+	span, ctx := tracing.CreateSpan(ctx, "nestedFunc", nil)
+	defer span.Finish()
+
+	time.Sleep(1 * time.Second)
+}
+
+func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	var request uppercaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	return json.NewEncoder(w).Encode(response)
+}

--- a/examples/httpGoKit-middleware/main.go
+++ b/examples/httpGoKit-middleware/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
-	"time"
 
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/ricardo-ch/go-tracing"
@@ -27,22 +25,8 @@ func main() {
 		encodeResponse,
 	)
 
-	http.Handle("/uppercase", tracing.HTTPMiddleware("hello-handler", uppercaseHandler))
+	http.Handle("/uppercase", tracing.HTTPMiddleware("uppercase-handler", uppercaseHandler))
 	http.ListenAndServe(":8000", nil)
-}
-
-func uppercase(w http.ResponseWriter, r *http.Request) {
-	time.Sleep(1 * time.Second)
-	nestedFunc(r.Context())
-
-	io.WriteString(w, "Hello world!")
-}
-
-func nestedFunc(ctx context.Context) {
-	span, ctx := tracing.CreateSpan(ctx, "nestedFunc", nil)
-	defer span.Finish()
-
-	time.Sleep(1 * time.Second)
 }
 
 func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {

--- a/examples/httpGoKit-middleware/model.go
+++ b/examples/httpGoKit-middleware/model.go
@@ -1,0 +1,10 @@
+package main
+
+type uppercaseRequest struct {
+	S string `json:"s"`
+}
+
+type uppercaseResponse struct {
+	V   string `json:"v"`
+	Err string `json:"err,omitempty"` // errors don't JSON-marshal, so we use a string
+}

--- a/examples/httpGoKit-middleware/service.go
+++ b/examples/httpGoKit-middleware/service.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+type StringService interface {
+	Uppercase(context.Context, string) (string, error)
+}
+
+type stringService struct{}
+
+func (stringService) Uppercase(_ context.Context, s string) (string, error) {
+	if s == "" {
+		return "", errors.New("Empty string")
+	}
+	return strings.ToUpper(s), nil
+}

--- a/examples/httpGoKit-middleware/service.go
+++ b/examples/httpGoKit-middleware/service.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
+
+	"github.com/ricardo-ch/go-tracing"
 )
 
 type StringService interface {
@@ -12,9 +15,19 @@ type StringService interface {
 
 type stringService struct{}
 
-func (stringService) Uppercase(_ context.Context, s string) (string, error) {
+func (stringService) Uppercase(ctx context.Context, s string) (string, error) {
 	if s == "" {
 		return "", errors.New("Empty string")
 	}
+	time.Sleep(1 * time.Second)
+	nestedFunc(ctx)
+
 	return strings.ToUpper(s), nil
+}
+
+func nestedFunc(ctx context.Context) {
+	span, ctx := tracing.CreateSpan(ctx, "nestedFunc", nil)
+	defer span.Finish()
+
+	time.Sleep(1 * time.Second)
 }

--- a/examples/httpServer-middleware/main.go
+++ b/examples/httpServer-middleware/main.go
@@ -18,7 +18,7 @@ func main() {
 	tracing.SetGlobalTracer(appName, "http://localhost:9411/")
 	defer tracing.FlushCollector()
 
-	http.Handle("/", tracing.HttpMiddleware("hello-handler", hello))
+	http.Handle("/", tracing.HTTPMiddleware("hello-handler", http.HandlerFunc(hello)))
 	http.ListenAndServe(":8000", nil)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// HttpMiddleware returns a Middleware that injects an OpenTracing Span found in
+// HTTPMiddleware returns a Middleware that injects an OpenTracing Span found in
 // context into the HTTP Headers.
-func HttpMiddleware(operationName string, next http.HandlerFunc) http.Handler {
+func HTTPMiddleware(operationName string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		tags := make(map[string]interface{})
 
@@ -33,6 +33,6 @@ func HttpMiddleware(operationName string, next http.HandlerFunc) http.Handler {
 		req = req.WithContext(ctx)
 
 		// next middleware or actual request handler
-		next(w, req)
+		next.ServeHTTP(w, req)
 	})
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -15,7 +15,7 @@ import (
 func TestMiddleware(t *testing.T) {
 	assert := assert.New(t)
 
-	ts := httptest.NewServer(HttpMiddleware("test-get", getTestHandler))
+	ts := httptest.NewServer(HTTPMiddleware("test-get", http.HandlerFunc(getTestHandler)))
 	defer ts.Close()
 
 	var u bytes.Buffer


### PR DESCRIPTION
Make the middleware accept an http.Handler instead of HandlerFunc.
HandlerFunc is an Handler.

Also provide an example with Go-kit