### PR TITLE
Improve library documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Go-tracing provides an easy way to use zipkin tracing with only four lines of co
 ## Quick start
 
 ```golang
+// import the library
+import "github.com/ricardo-ch/go-tracing"
+
 // set your tracer
 tracing.SetGlobalTracer(appName, "{zipkin_host}")
 defer tracing.FlushCollector()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Go-tracing provides an easy way to use zipkin tracing with only four lines of co
 import "github.com/ricardo-ch/go-tracing"
 
 // set your tracer
-tracing.SetGlobalTracer(appName, "{zipkin_host}")
+tracing.SetGlobalTracer(appName, "{zipkin_url}")
 defer tracing.FlushCollector()
 
 // define a trace

--- a/tracer.go
+++ b/tracer.go
@@ -14,8 +14,8 @@ func GetGlobalTracer() opentracing.Tracer {
 }
 
 //SetGlobalTracer ...
-func SetGlobalTracer(apiName string, zipKinAPIHost string) error {
-	tracer, err := createTracer(apiName, zipKinAPIHost)
+func SetGlobalTracer(apiName string, zipkinURL string) error {
+	tracer, err := createTracer(apiName, zipkinURL)
 	if err != nil {
 		return errors.Wrap(err, "SetGlobalTracer")
 	}
@@ -23,8 +23,8 @@ func SetGlobalTracer(apiName string, zipKinAPIHost string) error {
 	return nil
 }
 
-func createTracer(apiName string, zipKinAPIHost string) (opentracing.Tracer, error) {
-	collector, err := createCollector(zipKinAPIHost)
+func createTracer(apiName string, zipkinURL string) (opentracing.Tracer, error) {
+	collector, err := createCollector(zipkinURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "createTracer")
 	}
@@ -41,8 +41,8 @@ func createTracer(apiName string, zipKinAPIHost string) (opentracing.Tracer, err
 	return tracer, nil
 }
 
-func createCollector(zipKinAPIHost string) (zipkin.Collector, error) {
-	url := zipKinAPIHost + "/api/v1/spans"
+func createCollector(zipkinURL string) (zipkin.Collector, error) {
+	url := zipkinURL + "/api/v1/spans"
 	collector, err := zipkin.NewHTTPCollector(url)
 
 	if err != nil {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Test_setAndGetTracer_OK(t *testing.T) {
-	SetGlobalTracer("testAPIName","testHost")
+	SetGlobalTracer("testAPIName","http://testHost:9411")
 	tracer := GetGlobalTracer()
 	assert.NotNil(t, tracer)
 }


### PR DESCRIPTION
Having adopted the library, I would suggest by this PR a couple of improvements that would have helped me in the adoption.

- The README.md to include also the "import" statement (many popular libraries also document a "go get gitHub.com/..." command)
- The zipkinAPIHost argument to be renamed to zipkinURL (in the code, and in the README), for not tempting adopters to make the mistake of providing a (wrong) hostname rather than a (correct) full URL of the zipkin server.