### PR TITLE
Remove double check of ctx

### DIFF
--- a/span.go
+++ b/span.go
@@ -2,9 +2,9 @@ package tracing
 
 import (
 	"context"
-	"net/http"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"net/http"
 )
 
 //CreateSpan ...
@@ -32,9 +32,6 @@ func CreateSpanFromClientContext(r *http.Request, spanName string, tags *map[str
 
 	// store span in context
 	ctx := r.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	childCtx := opentracing.ContextWithSpan(ctx, span)
 
 	return span, childCtx
@@ -55,7 +52,7 @@ func setTags(span opentracing.Span, tags *map[string]interface{}) {
 
 // InjectIntoCarrier returns a textMapCarrier, basically a map[string]string,
 //  which can be used to transmit a span context to another service with ExtractFromCarrier
-func InjectIntoCarrier(ctx context.Context) opentracing.TextMapCarrier{
+func InjectIntoCarrier(ctx context.Context) opentracing.TextMapCarrier {
 	carrier := opentracing.TextMapCarrier{}
 
 	// Retrieve the Span from context


### PR DESCRIPTION
It's not necessary to check if the context is nil, and if it's the case create a ctx.Background(),
because since the function Context() was implemented on the request object (on go 1.7) it already does this check :

```golang
func (r *Request) Context() context.Context {
        if r.ctx != nil {
                return r.ctx
        }
        return context.Background()
}
```