### PR TITLE
Add the httptrace feature

### DIFF
--- a/clienttrace.go
+++ b/clienttrace.go
@@ -1,0 +1,68 @@
+package tracing
+
+import (
+	"net/http/httptrace"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// NewClientTrace Creates a New ClientTrace
+func newClientTrace(span opentracing.Span) *httptrace.ClientTrace {
+	trace := &clientTrace{span: span}
+	return &httptrace.ClientTrace{
+		DNSStart:             trace.dnsStart,
+		DNSDone:              trace.dnsDone,
+		GetConn:              trace.getConn,
+		GotConn:              trace.gotConn,
+		ConnectStart:         trace.connectStart,
+		ConnectDone:          trace.connectDone,
+		GotFirstResponseByte: trace.gotFirstResponseByte,
+		WroteRequest:         trace.wroteRequest,
+	}
+}
+
+// clientTrace holds a reference to the Span and
+// provides methods used as ClientTrace callbacks
+type clientTrace struct {
+	span opentracing.Span
+}
+
+func (h *clientTrace) dnsStart(info httptrace.DNSStartInfo) {
+	h.span.LogKV("event", "DNS Start",
+		"host", info.Host,
+	)
+}
+
+func (h *clientTrace) dnsDone(d httptrace.DNSDoneInfo) {
+	h.span.LogKV("event", "DNS done")
+}
+
+func (h *clientTrace) getConn(hostPort string) {
+	h.span.LogKV("event", "Get Connection")
+}
+
+func (h *clientTrace) gotConn(httptrace.GotConnInfo) {
+	h.span.LogKV("event", "Got Connection")
+}
+
+func (h *clientTrace) connectStart(network, addr string) {
+	h.span.LogKV("event", "Connection Start")
+}
+
+func (h *clientTrace) connectDone(network, addr string, err error) {
+	if err != nil {
+		h.span.LogKV("event", "Connection Done",
+			"err", err.Error(),
+		)
+	} else {
+		h.span.LogKV("event", "Connection Done")
+	}
+}
+
+func (h *clientTrace) wroteRequest(httptrace.WroteRequestInfo) {
+	h.span.LogKV("event", "Wrote Request")
+}
+
+func (h *clientTrace) gotFirstResponseByte() {
+	h.span.LogKV("event", "Got First Response byte")
+}

--- a/examples/httptrace-basic/README.md
+++ b/examples/httptrace-basic/README.md
@@ -1,0 +1,19 @@
+If you want to test, first start a zipkin server :
+
+```bash
+docker run -d -p 9411:9411 openzipkin/zipkin
+```
+
+then :
+
+```bash
+go run main.go
+```
+
+You can now go to find your trace on :
+
+```html
+http://localhost:9411/zipkin/
+```
+
+

--- a/examples/httptrace-basic/main.go
+++ b/examples/httptrace-basic/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptrace"
+	"os"
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/ricardo-ch/go-tracing"
+)
+
+// this name is use to identify traces inside zipkin UI
+const (
+	appName = "my-application"
+)
+
+func main() {
+	tracing.SetGlobalTracer(appName, "http://localhost:9411")
+	defer tracing.FlushCollector()
+
+	doWork(context.Background())
+}
+
+func doWork(ctx context.Context) {
+	span, ctx := tracing.CreateSpan(ctx, "doWork", nil)
+	defer span.Finish()
+
+	r, err := googleRequest(ctx)
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	option := func(trace *httptrace.ClientTrace, span opentracing.Span) {
+		trace.GotFirstResponseByte = func() {
+			span.LogKV("event", "Got First Response byte (changed)")
+		}
+	}
+
+	// Add The trace to the Request
+	r = tracing.InjectHTTPTraceSpan(r, option)
+	client := &http.Client{
+		Timeout: time.Duration(100) * (time.Millisecond),
+	}
+	client.Do(r)
+}
+
+func googleRequest(ctx context.Context) (r *http.Request, er error) {
+	r, er = http.NewRequest("GET", "http://www.google.ca/", nil) // ;)
+	if er != nil {
+		return nil, er
+
+	}
+	r = r.WithContext(ctx)
+
+	return r, nil
+}

--- a/examples/httptrace-basic/main.go
+++ b/examples/httptrace-basic/main.go
@@ -39,7 +39,7 @@ func doWork(ctx context.Context) {
 	}
 
 	// Add The trace to the Request
-	r = tracing.InjectHTTPTraceSpan(r, option)
+	r = tracing.InjectSpan(r, option)
 	client := &http.Client{
 		Timeout: time.Duration(100) * (time.Millisecond),
 	}

--- a/span.go
+++ b/span.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"net/http"
+	"net/http/httptrace"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -109,5 +110,20 @@ func InjectSpan(r *http.Request) *http.Request {
 			opentracing.HTTPHeadersCarrier(r.Header),
 		)
 	}
+	return r
+}
+
+// InjectHTTPTraceSpan Injects HttpTrace on the request
+func InjectHTTPTraceSpan(r *http.Request, trace *httptrace.ClientTrace) *http.Request {
+
+	if span := opentracing.SpanFromContext(r.Context()); span != nil {
+		if trace == nil {
+			trace = newClientTrace(span)
+		}
+
+		ctx := httptrace.WithClientTrace(r.Context(), trace)
+		r = r.WithContext(ctx)
+	}
+
 	return r
 }

--- a/span.go
+++ b/span.go
@@ -114,11 +114,12 @@ func InjectSpan(r *http.Request) *http.Request {
 }
 
 // InjectHTTPTraceSpan Injects HttpTrace on the request
-func InjectHTTPTraceSpan(r *http.Request, trace *httptrace.ClientTrace) *http.Request {
+func InjectHTTPTraceSpan(r *http.Request, options ...func(*httptrace.ClientTrace, opentracing.Span)) *http.Request {
 
 	if span := opentracing.SpanFromContext(r.Context()); span != nil {
-		if trace == nil {
-			trace = newClientTrace(span)
+		trace := newClientTrace(span)
+		for _, option := range options {
+			option(trace, span)
 		}
 
 		ctx := httptrace.WithClientTrace(r.Context(), trace)


### PR DESCRIPTION
In order to be able to trace the latency of the connection. I use the httptrace package from golang.
If trace is nil, we can set a default one, that trace the basics (you can add more callback functions if you want, this basic was define by looking what was needed on https://github.com/tcnksm/go-httpstat)

On zipkin the big overview will give you some dots (with hover labels) :

![zipkin span view](https://lh3.googleusercontent.com/4Axn8DI43vvaTblvif40UFT4cU2UHX04PJfyBGapabZIkUUqkLyhZKtMyTujZdJ6qv5QIWPQGH-uGRMYLkEI=w1853-h913)

And if you open the span, you will see each log, and the time when it occured (allowing you to see the latency) :

![zipkin span log](https://lh3.googleusercontent.com/4vJoIxsPhrZdGAARC-WhflFtbLt8f7Q6umHIKJaYwJpM0hHZ1n-4YsXCiUqp7b-HWS5SAR1dWziwtRc5SxY_=w1853-h913)